### PR TITLE
Add COMPOSER_BIN check to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+COMPOSER_BIN := $(shell command -v composer 2> /dev/null)
+ifndef COMPOSER_BIN
+    $(error composer is not available on your system, please install composer)
+endif
+
 app_name=$(notdir $(CURDIR))
 project_directory=$(CURDIR)/../$(app_name)
 build_tools_directory=$(CURDIR)/build/tools
@@ -6,7 +11,6 @@ source_package_name=$(source_build_directory)/$(app_name)
 appstore_build_directory=$(CURDIR)/build/artifacts/appstore
 appstore_package_name=$(appstore_build_directory)/$(app_name)
 npm=$(shell which npm 2> /dev/null)
-composer=$(shell which composer 2> /dev/null)
 
 occ=$(CURDIR)/../../occ
 private_key=$(HOME)/.owncloud/certificates/$(app_name).key
@@ -39,21 +43,11 @@ ifneq (,$(wildcard $(CURDIR)/js/package.json))
 	make npm
 endif
 
-# Installs and updates the composer dependencies. If composer is not installed
-# a copy is fetched from the web
+# Installs and updates the composer dependencies.
 .PHONY: composer
 composer:
-ifeq (, $(composer))
-	@echo "No composer command available, downloading a copy from the web"
-	mkdir -p $(build_tools_directory)
-	curl -sS https://getcomposer.org/installer | php
-	mv composer.phar $(build_tools_directory)
-	php $(build_tools_directory)/composer.phar install --prefer-dist
-	php $(build_tools_directory)/composer.phar update --prefer-dist
-else
 	composer install --prefer-dist
 	composer update --prefer-dist
-endif
 
 # Installs npm dependencies
 .PHONY: npm


### PR DESCRIPTION
Related to issue https://github.com/owncloud/QA/issues/609

Update to use the current "standard" way of checking for ``COMPOSER_BIN``

These days we are everywhere expecting that `composer` is already installed on a developer or CI system.