### PR TITLE
Adjust Travis and unit test code to pass with PHPunit 8.0

### DIFF
--- a/tests/unit/FtpTest.php
+++ b/tests/unit/FtpTest.php
@@ -31,7 +31,7 @@ use Test\Files\Storage\Storage;
 class FtpTest extends Storage {
 	private $config;
 
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 
 		$this->config = \json_decode(\file_get_contents('./tests/unit/config.json'), true);
@@ -40,7 +40,7 @@ class FtpTest extends Storage {
 		$this->instance->mkdir('');
 	}
 
-	protected function tearDown() {
+	protected function tearDown(): void {
 		if ($this->instance) {
 			$this->instance->disconnect();
 		}


### PR DESCRIPTION
Unit tests had various existing fails. When we run Travis with PHP 7.2 then it nowadays finds PHPunit 8.0. PHPunit 8.0 has added ``: void`` return type to methods in its ``TestCase`` class - see https://phpunit.readthedocs.io/en/8.0/fixtures.html

We inherit from that ``TestCase`` and so when we make methods like ``setUp()`` in a child class, we now have to specify the ``void`` return type, or PHP has a fit.
```
protected function setUp(): void {
```

And the unit test infrastructure used by apps inherits from core unit test code, which inherits from the PHPunit classes. So I have made a trial PR https://github.com/owncloud/core/pull/34481 in core that implements the new ``void`` return type stuff.

Then I use that as the ``CORE_BRANCH`` for testing here, and it passes - magic!

Against `core` ``stable10`` there are the problems that:
- if I run with PHP 5.6 then the unit test code here in the repo does not work - PHP 5.6 does not support specifying function return types.
- if I run with PHP 7.0 I get an older PHPunit and it complains about
```
TypeError: Return value of Test\Files_external_ftp\Ftp::setUp() must be an instance of Test\Files_external_ftp\void, none returned
```
- PHP 7.1 and 7.2 passes, because it accepts function return types without complaining if they are not specified properly in child classes

This is for after old PHP versions are dropped.