### PR TITLE
Adjust .travis.yml so it passes again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: php
 php:
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
 
@@ -34,6 +32,8 @@ before_install:
   - wget https://raw.githubusercontent.com/owncloud/administration/master/travis-ci/before_install.sh
   - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DB
   - cd ../core
+  - composer install
+  - bash ./core_install.sh $DB
   - php occ app:enable files_external
   - php occ app:enable $APP_NAME
 
@@ -45,11 +45,20 @@ script:
   # Run phpunit tests
   - cd tests
   - echo '{"host":"localhost","username":"test","password":"test"}' > config.json
-  - phpunit --configuration phpunit.xml
+  - ../../../lib/composer/bin/phpunit --configuration phpunit.xml
 
   # Create coverage report
   - sh -c "if [ '$TRAVIS_PHP_VERSION' != 'hhvm' ]; then wget https://scrutinizer-ci.com/ocular.phar; fi"
   - sh -c "if [ '$TRAVIS_PHP_VERSION' != 'hhvm' ]; then php ocular.phar code-coverage:upload --format=php-clover clover.xml; fi"
 
 matrix:
+  include:
+    - php: 5.6
+      env: FTPD=proftpd CORE_BRANCH=stable10
+    - php: 7.0
+      env: FTPD=proftpd CORE_BRANCH=stable10
+    - php: 5.6
+      env: FTPD=vsftpd CORE_BRANCH=stable10
+    - php: 7.0
+      env: FTPD=vsftpd CORE_BRANCH=stable10
   fast_finish: true


### PR DESCRIPTION
It has been a year since an ordinary pass of CI in this repo. Before moving to drone, get the travis CI going so we know that something works.

1) core `master` no longer supports PHP 5.6 or 7.0. Adjust the matrix in travis so it only runs PHP 5.6 and 7.0 against core `stable10`

2) These days on Travis with PHP 7.2 we get `phpunit` v8 built-in. That results in errors being reported in the unit test code, because `phpunit` v8 adds return types to `setUp()` and `tearDown()` methods. We inherit those classes in some base test classes in core. Changes would have to be made in core `master` to support `phpunit` v8. Anyway we want to run whatever `phpunit` version is run in the core branch that we are testing against, so do that.

3) The https://raw.githubusercontent.com/owncloud/administration/master/travis-ci/before_install.sh script was getting errors when it tried to run `core_install.sh` And `composer install` did not end up happening. We did not have a properly-installed ownCloud, and we did not have a `phpunit` available in that ownCloud. Put those setup things directly in `.travis.yml`. (We are not going to try to debug all that now an "fix" it in `owncloud/administration/master/travis-ci` -that is now out-of-date code that dies)