### PR TITLE
Add codecov to drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -237,6 +237,7 @@ matrix:
       NEED_CORE: true
       NEED_INSTALL_APP: true
       FTP_TYPE: proftp
+      COVERAGE: true
 
     - PHP_VERSION: 5.6
       OC_VERSION: daily-stable10-qa


### PR DESCRIPTION
Collect code coverage data when running PHP unit tests with PHP 7.2
I chose that, because it is the PHP version that would currently be the version of choice for a new installation.

Part of issue #28 