### PR TITLE
Drop PHP 5.6

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -206,9 +206,6 @@ services:
 matrix:
   include:
     # owncloud-coding-standard
-    - PHP_VERSION: 5.6
-      TEST_SUITE: owncloud-coding-standard
-
     - PHP_VERSION: 7.0
       TEST_SUITE: owncloud-coding-standard
 
@@ -238,15 +235,6 @@ matrix:
       NEED_INSTALL_APP: true
       FTP_TYPE: proftp
       COVERAGE: true
-
-    - PHP_VERSION: 5.6
-      OC_VERSION: daily-stable10-qa
-      TEST_SUITE: phpunit
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      FTP_TYPE: proftp
 
     - PHP_VERSION: 7.0
       OC_VERSION: daily-stable10-qa
@@ -287,15 +275,6 @@ matrix:
 
     - PHP_VERSION: 7.2
       OC_VERSION: daily-master-qa
-      TEST_SUITE: phpunit
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      FTP_TYPE: vsftp
-
-    - PHP_VERSION: 5.6
-      OC_VERSION: daily-stable10-qa
       TEST_SUITE: phpunit
       DB_TYPE: mysql
       DB_NAME: owncloud


### PR DESCRIPTION
core stable10 no longer supports PHP 5.6
https://github.com/owncloud/core/pull/34698