### PR TITLE
[tests-only] Bump phan from 2.7 to 3.2

### DIFF
--- a/vendor-bin/phan/composer.json
+++ b/vendor-bin/phan/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "phan/phan": "^2.7"
+        "phan/phan": "^3.2"
     }
 }


### PR DESCRIPTION
This has been done in some other oC10 app repos. Do it here similar to https://github.com/owncloud/core/pull/38122

This app is small enough that the new major version does not find anything new to report.