### PR TITLE
[tests-only] wait for ftp servers to come up in CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -34,6 +34,7 @@ config = {
 					'pull': 'always',
 					'commands': [
 						'echo \'{"host":"proftp","username":"test","password":"test"}\' > tests/unit/config.json',
+						'wait-for-it -t 600 proftp:21',
 					]
 				}
 			],
@@ -67,6 +68,7 @@ config = {
 					'pull': 'always',
 					'commands': [
 						'echo \'{"host":"vsftp","username":"test","password":"test"}\' > tests/unit/config.json',
+						'wait-for-it -t 600 vsftp:21',
 					]
 				}
 			],


### PR DESCRIPTION
Because `fauria/vsftpd` docker image seems to be slow coming (or now it got rate-limited? or?)
https://drone.owncloud.com/owncloud/files_external_ftp/736/9/3